### PR TITLE
add imagePullPolicy to grafana job tasks

### DIFF
--- a/manifests/grafana/import-dashboards/job.yaml
+++ b/manifests/grafana/import-dashboards/job.yaml
@@ -18,6 +18,7 @@ spec:
           {
             "name": "wait-for-endpoints",
             "image": "giantswarm/tiny-tools",
+            "imagePullPolicy": "IfNotPresent",
             "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[].addresses | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
             "args": ["monitoring", "grafana"]
           }


### PR DESCRIPTION
fixes: issue #40

added `"imagePullPolicy": "IfNotPresent"` to `./manifests/grafana/import-dashboards/jobs.yaml`.