### PR TITLE
Fix path of grafana-import-dashboards-job.yaml

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ _Note:_ If persistent storage is not set up in your cluster, the preset datasour
 
 ```nohighlight
 kubectl --namespace=monitoring delete job grafana-import-dashboards
-kubectl --namespace=monitoring create --filename https://raw.githubusercontent.com/giantswarm/kubernetes-prometheus/master/manifests/grafana-import-dashboards-job.yaml
+kubectl --namespace=monitoring create --filename https://raw.githubusercontent.com/giantswarm/kubernetes-prometheus/master/manifests/grafana/import-dashboards/job.yaml
 ```
 
 ## Next Steps


### PR DESCRIPTION
Hey Ho,

there seems to be a wrong path in the import-dashboards-job in the docs.

Greetings, Thomas