### PR TITLE
Improve resiliency of the dashboard-importer wait-for-endpoint init container.

### DIFF
--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -1920,7 +1920,7 @@ spec:
             "name": "wait-for-endpoints",
             "image": "giantswarm/tiny-tools",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[].addresses | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
+            "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[]?.addresses // [] | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
             "args": ["monitoring", "grafana"]
           }
         ]'

--- a/manifests/grafana/import-dashboards/job.yaml
+++ b/manifests/grafana/import-dashboards/job.yaml
@@ -19,7 +19,7 @@ spec:
             "name": "wait-for-endpoints",
             "image": "giantswarm/tiny-tools",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[].addresses | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
+            "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[]?.addresses // [] | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
             "args": ["monitoring", "grafana"]
           }
         ]'


### PR DESCRIPTION
I modified the dashboard-importer wait-for-endpoint init container to behave when the kubernetes master output does not list endpoint for grafana service (eg. before the service is available).

This should avoid the following errors in the wait-for-endpoints logs:

```sh
waiting...
test: Missing argument at index 2 # <---- avoids this
{
  "kind": "Endpoints",
  "apiVersion": "v1",
  "metadata": {
    "name": "grafana",
    "namespace": "monitoring",
    "selfLink": "/api/v1/namespaces/monitoring/endpoints/grafana",
    "uid": "48e620cf-f2a6-11e6-9cc3-0800278fef23",
    "resourceVersion": "789",
    "creationTimestamp": "2017-02-14T11:11:08Z",
    "labels": {
      "app": "grafana",
      "component": "core"
    }
  },
  "subsets": []
}
```

Test:

```sh
# when unexpected json response
root@1cc818a9f6d1:/# export endpoints='{   "kind": "Status",   "apiVersion": "v1",   "metadata": {},   "status": "Failure",   "message": "User \"system:anonymous\" cannot get endpoints in project \"monitoring\"",   "reason": "Forbidden",   "details": {     "name": "grafana",     "kind": "endpoints"   },   "code": 403 }'
root@1cc818a9f6d1:/#  echo $endpoints | jq -r ".subsets[]?.addresses // [] | length"
0
# when response listing at least an endpoint
root@1cc818a9f6d1:/# endpoints2='{
>   "kind": "Endpoints",
>   "apiVersion": "v1",
>   "metadata": {
>     "name": "grafana",
>     "namespace": "monitoring",
>     "selfLink": "/api/v1/namespaces/monitoring/endpoints/grafana",
>     "uid": "48e620cf-f2a6-11e6-9cc3-0800278fef23",
>     "resourceVersion": "1834",
>     "creationTimestamp": "2017-02-14T11:11:08Z",
>     "labels": {
>       "app": "grafana",
>       "component": "core"
>     }
>   },
>   "subsets": [
>     {
>       "addresses": [
>         {
>           "ip": "10.128.0.14",
>           "nodeName": "master",
>           "targetRef": {
>             "kind": "Pod",
>             "namespace": "monitoring",
>             "name": "grafana-core-1-tbqlt",
>             "uid": "2c3322a9-f2a7-11e6-9cc3-0800278fef23",
>             "resourceVersion": "1831"
>           }
>         }
>       ],
>       "ports": [
>         {
>           "port": 3000,
>           "protocol": "TCP"
>         }
>       ]
>     }
>   ]
> }
> '
root@1cc818a9f6d1:/# echo $endpoints2 | jq -r ".subsets[]?.addresses // [] | length"
1
```