### PR TITLE
add rbac etc

### DIFF
--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -18,7 +18,7 @@ subjects:
   name: kube-state-metrics
   namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics
@@ -27,7 +27,10 @@ rules:
   resources:
   - nodes
   - pods
+  - services
   - resourcequotas
+  - replicationcontrollers
+  - limitranges
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:

--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -18,7 +18,7 @@ subjects:
   name: kube-state-metrics
   namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics

--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -5,6 +5,81 @@ kind: Namespace
 metadata:
   name: monitoring
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - pods
+  - resourcequotas
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-k8s
+  namespace: monitoring
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -22,7 +97,7 @@ spec:
         component: core
     spec:
       containers:
-      - image: grafana/grafana:4.1.1
+      - image: grafana/grafana:4.2.0
         name: grafana-core
         imagePullPolicy: IfNotPresent
         # env:
@@ -1925,6 +2000,7 @@ spec:
           }
         ]'
     spec:
+      serviceAccountName: prometheus-k8s
       containers:
       - name: grafana-import-dashboards
         image: giantswarm/tiny-tools
@@ -2107,11 +2183,12 @@ spec:
         app: prometheus
         component: core
     spec:
+      serviceAccountName: prometheus-k8s
       containers:
       - name: prometheus
         image: prom/prometheus:v1.5.2
         args:
-          - '-storage.local.retention=6h'
+          - '-storage.local.retention=12h'
           - '-storage.local.memory-chunks=500000'
           - '-config.file=/etc/prometheus/prometheus.yml'
         ports:
@@ -2138,12 +2215,13 @@ metadata:
   name: kube-state-metrics
   namespace: monitoring
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
         app: kube-state-metrics
     spec:
+      serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
         image: gcr.io/google_containers/kube-state-metrics:v0.4.1

--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -1920,7 +1920,7 @@ spec:
             "name": "wait-for-endpoints",
             "image": "giantswarm/tiny-tools",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[].addresses | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
+            "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[]?.addresses // [] | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
             "args": ["monitoring", "grafana"]
           }
         ]'

--- a/manifests/grafana/import-dashboards/job.yaml
+++ b/manifests/grafana/import-dashboards/job.yaml
@@ -24,6 +24,7 @@ spec:
           }
         ]'
     spec:
+      serviceAccountName: prometheus-k8s
       containers:
       - name: grafana-import-dashboards
         image: giantswarm/tiny-tools

--- a/manifests/grafana/import-dashboards/job.yaml
+++ b/manifests/grafana/import-dashboards/job.yaml
@@ -19,7 +19,7 @@ spec:
             "name": "wait-for-endpoints",
             "image": "giantswarm/tiny-tools",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[].addresses | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
+            "command": ["fish", "-c", "echo \"waiting for endpoints...\"; while true; set endpoints (curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header \"Authorization: Bearer \"(cat /var/run/secrets/kubernetes.io/serviceaccount/token) https://kubernetes.default.svc/api/v1/namespaces/monitoring/endpoints/grafana); echo $endpoints | jq \".\"; if test (echo $endpoints | jq -r \".subsets[]?.addresses // [] | length\") -gt 0; exit 0; end; echo \"waiting...\";sleep 1; end"],
             "args": ["monitoring", "grafana"]
           }
         ]'

--- a/manifests/prometheus/deployment.yaml
+++ b/manifests/prometheus/deployment.yaml
@@ -15,11 +15,12 @@ spec:
         app: prometheus
         component: core
     spec:
+      serviceAccountName: prometheus-k8s
       containers:
       - name: prometheus
-        image: prom/prometheus:v1.5.2
+        image: prom/prometheus:v1.6.1
         args:
-          - '-storage.local.retention=6h'
+          - '-storage.local.retention=12h'
           - '-storage.local.memory-chunks=500000'
           - '-config.file=/etc/prometheus/prometheus.yml'
         ports:

--- a/manifests/prometheus/kube-state-metrics/deployment.yaml
+++ b/manifests/prometheus/kube-state-metrics/deployment.yaml
@@ -4,12 +4,13 @@ metadata:
   name: kube-state-metrics
   namespace: monitoring
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
         app: kube-state-metrics
     spec:
+      serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
         image: gcr.io/google_containers/kube-state-metrics:v0.4.1

--- a/manifests/prometheus/kube-state-metrics/rbac.yaml
+++ b/manifests/prometheus/kube-state-metrics/rbac.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - pods
+  - resourcequotas
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring

--- a/manifests/prometheus/kube-state-metrics/rbac.yaml
+++ b/manifests/prometheus/kube-state-metrics/rbac.yaml
@@ -12,7 +12,7 @@ subjects:
   name: kube-state-metrics
   namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics
@@ -21,7 +21,10 @@ rules:
   resources:
   - nodes
   - pods
+  - services
   - resourcequotas
+  - replicationcontrollers
+  - limitranges
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:

--- a/manifests/prometheus/kube-state-metrics/rbac.yaml
+++ b/manifests/prometheus/kube-state-metrics/rbac.yaml
@@ -12,7 +12,7 @@ subjects:
   name: kube-state-metrics
   namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics

--- a/manifests/prometheus/rbac.yaml
+++ b/manifests/prometheus/rbac.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-k8s
+  namespace: monitoring


### PR DESCRIPTION
- add rbac for 2 deploy and 1 job
- update grafana and prometheus version
- change kube-state-metrics replicas to 2
- set storage.local.retention=12h

owner can pick some to merge or give a answer to someone who want a clean 'readonly' permission
