### PR TITLE
Fix import job command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ kubectl delete namespace monitoring
 
 If you want to re-import the default dashboards from this setup run this job:
 ```bash
-kubectl apply --filename ./manifests/grafana/grafana-import-dashboards-job.yaml
+kubectl apply --filename ./manifests/grafana/import-dashboards/job.yaml
 ```
 
 In case the job already exists from an earlier run, delete it before:


### PR DESCRIPTION
Looks like the `job.yaml` moved to the import-dashboards subfolder.