### PR TITLE
Updates for 1.7 cadvisor changes and rbac requirements

### DIFF
--- a/configs/grafana/grafana-net-2-dashboard.json
+++ b/configs/grafana/grafana-net-2-dashboard.json
@@ -199,7 +199,7 @@
         "step": 4
       }],
       "thresholds": "500,4000",
-      "title": "Interal Storage Queue Length",
+      "title": "Internal Storage Queue Length",
       "type": "singlestat",
       "valueFontSize": "70%",
       "valueMaps": [{

--- a/configs/prometheus/prometheus.yaml
+++ b/configs/prometheus/prometheus.yaml
@@ -101,3 +101,20 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_container_port_number]
         action: keep
         regex: 9\d{3}
+  - job_name: 'kubernetes-cadvisor'
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      - action: labelmap
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor

--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -278,9 +278,9 @@ data:
       - match:
           severity: slack
         receiver: slack_alert
-      - match:
-          severity: email
-       receiver: email_alert
+      # - match:
+      #     severity: email
+      #   receiver: email_alert
 
     receivers:
     - name: 'default'

--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -404,7 +404,7 @@ spec:
           # timeoutSeconds: 1
         volumeMounts:
         - name: grafana-persistent-storage
-          mountPath: /var
+          mountPath: /var/lib/grafana
       volumes:
       - name: grafana-persistent-storage
         emptyDir: {}
@@ -613,7 +613,7 @@ data:
             "step": 4
           }],
           "thresholds": "500,4000",
-          "title": "Interal Storage Queue Length",
+          "title": "Internal Storage Queue Length",
           "type": "singlestat",
           "valueFontSize": "70%",
           "valueMaps": [{
@@ -2455,6 +2455,23 @@ data:
           - source_labels: [__meta_kubernetes_pod_container_port_number]
             action: keep
             regex: 9\d{3}
+      - job_name: 'kubernetes-cadvisor'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -2802,6 +2819,7 @@ metadata:
 # - apiGroups: [""]
 #   resources:
 #   - nodes
+#   - nodes/proxy
 #   - services
 #   - endpoints
 #   - pods

--- a/manifests/alertmanager/configmap.yaml
+++ b/manifests/alertmanager/configmap.yaml
@@ -65,9 +65,9 @@ data:
       - match:
           severity: slack
         receiver: slack_alert
-      - match:
-          severity: email
-        receiver: email_alert
+      # - match:
+      #     severity: email
+      #   receiver: email_alert
 
     receivers:
     - name: 'default'

--- a/manifests/grafana/import-dashboards/configmap.yaml
+++ b/manifests/grafana/import-dashboards/configmap.yaml
@@ -202,7 +202,7 @@ data:
             "step": 4
           }],
           "thresholds": "500,4000",
-          "title": "Interal Storage Queue Length",
+          "title": "Internal Storage Queue Length",
           "type": "singlestat",
           "valueFontSize": "70%",
           "valueMaps": [{

--- a/manifests/prometheus/configmap.yaml
+++ b/manifests/prometheus/configmap.yaml
@@ -104,6 +104,23 @@ data:
           - source_labels: [__meta_kubernetes_pod_container_port_number]
             action: keep
             regex: 9\d{3}
+      - job_name: 'kubernetes-cadvisor'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/manifests/prometheus/rbac.yaml
+++ b/manifests/prometheus/rbac.yaml
@@ -20,6 +20,7 @@
 # - apiGroups: [""]
 #   resources:
 #   - nodes
+#   - nodes/proxy
 #   - services
 #   - endpoints
 #   - pods


### PR DESCRIPTION
Notes:
- I'm not enabling rbac - but have at least made appropriate changes to the commented rbac rules. This works with rbac enabled with kubeadm-generated clusters.
- I've included joshes' /var/lib/grafana fix, though I see he also has a separate pull request for that

See also:
- prometheus/prometheus#2606
- prometheus/prometheus#2918
- kubernetes/charts#1655
- kubernetes/kubernetes#48483