### PR TITLE
Changes kube-state-metrics to use 1 replica

### DIFF
--- a/manifests/prometheus/kube-state-metrics/deployment.yaml
+++ b/manifests/prometheus/kube-state-metrics/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kube-state-metrics
   namespace: monitoring
 spec:
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
With using endpoints for scrape targets, having multiple ksm pods
will lead to metrics being repeated (more accurately, multiple
targets returning the 'same' metrics).

HA isn't really a massive issue here - in the case that ksm is lost,
a new one will be created, which prometheus will then scrape.