### PR TITLE
Remove Grafana ldap configuration

### DIFF
--- a/helm/kubernetes-prometheus-chart/README.md
+++ b/helm/kubernetes-prometheus-chart/README.md
@@ -149,34 +149,32 @@ Parameter | Description | Default
 `serverFiles.prometheus.yml` | Prometheus server scrape configuration | example configuration
 `extraScrapeConfigs` | Prometheus server additional scrape configuration | ""
 `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
-`grafana.replicas` | Number of nodes | `1` 
-`grafana.deploymentStrategy` | Deployment strategy | `RollingUpdate` 
+`grafana.replicas` | Number of nodes | `1`
+`grafana.deploymentStrategy` | Deployment strategy | `RollingUpdate`
 `grafana.livenessProbe` | Liveness Probe settings | `{ "httpGet": { "path": "/api/health", "port": 3000 } "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10 }
-`grafana.readinessProbe` | Rediness Probe settings | `{ "httpGet": { "path": "/api/health", "port": 3000 } 
-`grafana.securityContext` | Deployment securityContext | `{"runAsUser": 472, "fsGroup": 472}` 
-`grafana.image.repository` | Image repository | `grafana/grafana` 
-`grafana.image.tag` | Image tag. (`Must be >= 5.0.0`) | `5.3.4` 
-`grafana.image.pullPolicy` | Image pull policy | `IfNotPresent` 
-`grafana.service.type` | Kubernetes service type | `ClusterIP` 
-`grafana.service.port` | Kubernetes port where service is exposed | `80` 
-`grafana.service.annotations` | Service annotations | `{}` 
-`grafana.service.labels` | Custom labels | `{}` 
-`grafana.ingress.enabled` | Enables Ingress | `false` 
-`grafana.ingress.annotations` | Ingress annotations | `{}` 
-`grafana.ingress.labels` | Custom labels | `{}` 
-`grafana.ingress.hosts` | Ingress accepted hostnames | `[]` 
-`grafana.ingress.tls` | Ingress TLS configuration | `[]` 
-`grafana.resources` | CPU/Memory resource requests/limits | `{}` 
-`grafana.nodeSelector` | Node labels for pod assignment | `{}` 
-`grafana.tolerations` | Toleration labels for pod assignment | `[]` 
-`grafana.affinity` | Affinity settings for pod assignment | `{}` 
-`grafana.schedulerName` | Alternate scheduler name | `nil` 
-`grafana.env` | Extra environment variables passed to pods | `{}` 
-`grafana.custom.ini` | Grafana's primary configuration | `{}` 
-`grafana.ldap.existingSecret` | The name of an existing secret containing the `ldap.toml` file, this must have the key `ldap-toml`. | `""` |
-`grafana.ldap.config  ` | Grafana's LDAP configuration | `""` 
-`grafana.annotations` | Deployment annotations | `{}` 
-`grafana.podAnnotations` | Pod annotations | `{}` 
+`grafana.readinessProbe` | Rediness Probe settings | `{ "httpGet": { "path": "/api/health", "port": 3000 }
+`grafana.securityContext` | Deployment securityContext | `{"runAsUser": 472, "fsGroup": 472}`
+`grafana.image.repository` | Image repository | `grafana/grafana`
+`grafana.image.tag` | Image tag. (`Must be >= 5.0.0`) | `5.3.4`
+`grafana.image.pullPolicy` | Image pull policy | `IfNotPresent`
+`grafana.service.type` | Kubernetes service type | `ClusterIP`
+`grafana.service.port` | Kubernetes port where service is exposed | `80`
+`grafana.service.annotations` | Service annotations | `{}`
+`grafana.service.labels` | Custom labels | `{}`
+`grafana.ingress.enabled` | Enables Ingress | `false`
+`grafana.ingress.annotations` | Ingress annotations | `{}`
+`grafana.ingress.labels` | Custom labels | `{}`
+`grafana.ingress.hosts` | Ingress accepted hostnames | `[]`
+`grafana.ingress.tls` | Ingress TLS configuration | `[]`
+`grafana.resources` | CPU/Memory resource requests/limits | `{}`
+`grafana.nodeSelector` | Node labels for pod assignment | `{}`
+`grafana.tolerations` | Toleration labels for pod assignment | `[]`
+`grafana.affinity` | Affinity settings for pod assignment | `{}`
+`grafana.schedulerName` | Alternate scheduler name | `nil`
+`grafana.env` | Extra environment variables passed to pods | `{}`
+`grafana.custom.ini` | Grafana's primary configuration | `{}`
+`grafana.annotations` | Deployment annotations | `{}`
+`grafana.podAnnotations` | Pod annotations | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/helm/kubernetes-prometheus-chart/templates/grafana-deployment.yaml
+++ b/helm/kubernetes-prometheus-chart/templates/grafana-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     type: {{ .Values.grafana.deploymentStrategy }}
   {{- if ne .Values.grafana.deploymentStrategy "RollingUpdate" }}
     rollingUpdate: null
-  {{- end }}    
+  {{- end }}
   template:
     metadata:
       labels:
@@ -129,11 +129,7 @@ spec:
             name: {{ template "prometheus.grafana.fullname" . }}
         - name: ldap
           secret:
-            {{- if .Values.grafana.ldap.existingSecret }}
-            secretName: {{ .Values.grafana.ldap.existingSecret }}
-            {{- else }}
             secretName: {{ template "prometheus.grafana.fullname" . }}
-            {{- end }}
             items:
               - key: ldap-toml
                 path: ldap.toml

--- a/helm/kubernetes-prometheus-chart/templates/grafana-secret.yaml
+++ b/helm/kubernetes-prometheus-chart/templates/grafana-secret.yaml
@@ -16,6 +16,3 @@ data:
   {{- else }}
   admin-password: {{ randAlphaNum 40 | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.grafana.ldap.existingSecret }}
-  ldap-toml: {{ .Values.grafana.ldap.config | b64enc | quote }}
-  {{- end }}

--- a/helm/kubernetes-prometheus-chart/values.yaml
+++ b/helm/kubernetes-prometheus-chart/values.yaml
@@ -210,7 +210,7 @@ configmapReload:
 
   ## Additional configmap-reload mounts
   ##
-  extraConfigmapMounts: 
+  extraConfigmapMounts:
     - name: prometheus-alerts
       mountPath: /etc/prometheus-rules/prometheus.rules.yml
       configMap: prometheus-rules
@@ -894,35 +894,13 @@ grafana:
       mode: console
     grafana_net:
       url: https://grafana.net
-      
+
   ## LDAP Authentication can be enabled with the following values on grafana.ini
   ## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
     # auth.ldap:
     #   enabled: true
     #   allow_sign_up: true
     #   config_file: /etc/grafana/ldap.toml
-
-  ## Grafana's LDAP configuration
-  ## Templated by the template in _helpers.tpl
-  ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
-  ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
-  ## ref: http://docs.grafana.org/installation/ldap/#configuration
-  ldap:
-    # `existingSecret` is a reference to an existing secret containing the ldap configuration
-    # for Grafana in a key `ldap-toml`.
-    existingSecret: ""
-    # `config` is the content of `ldap.toml` that will be stored in the created secret
-    config: ""
-    # config: |-
-    #   verbose_logging = true
-
-    #   [[servers]]
-    #   host = "my-ldap-server"
-    #   port = 636
-    #   use_ssl = true
-    #   start_tls = false
-    #   ssl_skip_verify = false
-    #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
 
   ## Grafana's SMTP configuration
   ## NOTE: To enable, grafana.ini must be configured with smtp.enabled


### PR DESCRIPTION
Split-off: https://github.com/giantswarm/kubernetes-prometheus/pull/110 
Right now our CI, cannot handle double brackets `[[..]]` in the templates.
Remove the unsused grafana ldap configuration till we can handle it.

Diff is a bit weird, but its just removing the according config lines.