### PR TITLE
Configure Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+orbs:
+  architect: giantswarm/architect@0.1.1
+
+workflows:
+  package-and-push-chart-on-tag:
+    jobs:
+      - architect/push-to-app-catalog:
+          name: "package and push kubernetes-prometheus-chart"
+          app_catalog: "giantswarm-incubator-catalog"
+          app_catalog_test: "giantswarm-incubator-test-catalog"
+          chart: "kubernetes-prometheus-chart"
+          # Trigger job on git tag.
+          filters:
+            tags:
+              only: /^v.*/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/giantswarm/kubernetes-prometheus.svg?style=shield)](https://circleci.com/gh/giantswarm/kubernetes-prometheus)
+
 # Kubernetes prometheus operator chart
 
 Giant Swarm offers a Prometheus Operator Managed App in top of the tenant clusters. Here we define the prometheus chart with all Kubernetes templates and the default configuration.

--- a/helm/kubernetes-prometheus-chart/Chart.yaml
+++ b/helm/kubernetes-prometheus-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: A Helm Chart for Prometheus Operator.
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 name: kubernetes-prometheus-chart
-version: 0.1.0
+version: [[ .Version ]]
 appVersion: 0.30.1


### PR DESCRIPTION
This PR defines initial Circle CI configuration. Configuration makes use of `architect-orb` and defines workflow with a job for packaging and pushing prometheus operator chart packages, from PR branch and release tag to [giantswarm-incubator-test](https://github.com/giantswarm/giantswarm-incubator-test-catalog) and [giantswarm-incubator](https://github.com/giantswarm/giantswarm-incubator-catalog) catalog, respectively.